### PR TITLE
Trigger blur event after filling in the form.

### DIFF
--- a/javascripts/deserialize.js
+++ b/javascripts/deserialize.js
@@ -57,6 +57,7 @@
                         $current.val($currentSavedValue);
                     }
                     triggerNativeEvent($current, 'change');
+                    triggerNativeEvent($current, 'blur');
                     return true;
                 }
 
@@ -66,6 +67,7 @@
                     } else {
                         $current.val($currentSavedValue);
                         triggerNativeEvent($current, 'change');
+                        triggerNativeEvent($current, 'blur');
                     }
                     return true;
                 }
@@ -92,6 +94,7 @@
                             $(this).attr('checked', false);
                         }
                         triggerNativeEvent($current, 'change');
+                        triggerNativeEvent($current, 'blur');
                     }
                     return true;
                 }
@@ -103,6 +106,7 @@
                         $current.val($currentSavedValue);
                     }
                     triggerNativeEvent($current, 'change');
+                    triggerNativeEvent($current, 'blur');
                     return true;
                 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
 				"run_at" : "document_start"
 				} ],
 	"name": "Web Developer Form Filler",
-	"version": "1.0.10",
+	"version": "1.0.11",
 	"icons" : { 
 			"16" :  "images/16.png",
 		    "48" :  "images/48.png",


### PR DESCRIPTION
Some js validation libraries use the 'blur' event to validate form data. This change fixes the problem where the form is marked invalid despite all the fields containing the correct input.